### PR TITLE
9.1.0

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { configureStore, createSlice as createReduxSlice, } from "@reduxjs/toolkit";
-import { Provider as ReduxProvider, useSelector, useDispatch, } from "react-redux";
+import { Provider as ReduxProvider, createSelectorHook, createDispatchHook, } from "react-redux";
 const __SET_INIT_PERSISTED_STATE_RN__ = "__SET_INIT_PERSISTED_STATE_RN__";
 const createReduxSliceWrapper = (name, reducers, initialState) => {
     const reduxSlice = {
@@ -112,6 +112,9 @@ const getHookAndProviderFromSlices = ({ slices = {}, AsyncStorage = null, reduxS
         providers: [],
         reduxSlices: [],
     });
+    const SpecificContext = React.createContext(null);
+    const useDispatch = createDispatchHook(SpecificContext);
+    const useSelector = createSelectorHook(SpecificContext);
     const useContextSlice = (name) => {
         const { [name]: value } = useValues(name);
         const { [name]: actions } = useActions();
@@ -143,7 +146,7 @@ const getHookAndProviderFromSlices = ({ slices = {}, AsyncStorage = null, reduxS
             reducer,
             ...reduxStoreOptions,
         });
-        return React.createElement(ReduxProvider, { store: store }, children);
+        return (React.createElement(ReduxProvider, { context: SpecificContext, store: store }, children));
     };
     const Provider = composeProviders([...providers, ReduxProviderWrapper]);
     return {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-context-slices",
-  "version": "9.0.14",
+  "version": "9.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-context-slices",
-      "version": "9.0.14",
+      "version": "9.1.0",
       "license": "ISC",
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-context-slices",
-  "version": "9.0.14",
+  "version": "9.1.0",
   "description": "react-context-slices offers a unique solution to global state management in React by seamlessly integrating both Redux and React Context with zero-boilerplate",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -5,8 +5,8 @@ import {
 } from "@reduxjs/toolkit";
 import {
   Provider as ReduxProvider,
-  useSelector,
-  useDispatch,
+  createSelectorHook,
+  createDispatchHook,
 } from "react-redux";
 
 const __SET_INIT_PERSISTED_STATE_RN__ = "__SET_INIT_PERSISTED_STATE_RN__";
@@ -223,6 +223,9 @@ const getHookAndProviderFromSlices = ({
         reduxSlices: [],
       }
     );
+  const SpecificContext = React.createContext(null);
+  const useDispatch = createDispatchHook(SpecificContext);
+  const useSelector = createSelectorHook(SpecificContext);
   const useContextSlice = (name) => {
     const { [name]: value } = useValues(name);
     const { [name]: actions } = useActions();
@@ -257,7 +260,11 @@ const getHookAndProviderFromSlices = ({
       reducer,
       ...reduxStoreOptions,
     });
-    return <ReduxProvider store={store}>{children}</ReduxProvider>;
+    return (
+      <ReduxProvider context={SpecificContext} store={store}>
+        {children}
+      </ReduxProvider>
+    );
   };
   const Provider = composeProviders([...providers, ReduxProviderWrapper]);
   return {


### PR DESCRIPTION
allow for more than one context in redux provider. this is useful for micro-frontend projects, where we have a shared state and a local shared state per microfront-end project.